### PR TITLE
docs: add comprehensive documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,243 @@
 # elx-nodegroup-controller
 
-A tiny controller for persisting labels and taints on a list of nodes.
+A Kubernetes controller that automatically applies and persists labels and taints across groups of nodes. Define a `NodeGroup` resource and the controller will ensure all member nodes carry the specified labels and taints — even if they are manually removed or if nodes are replaced.
 
+## Table of Contents
 
-## Deploy controller and CRD
+- [Overview](#overview)
+- [How It Works](#how-it-works)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [NodeGroup API Reference](#nodegroup-api-reference)
+  - [Examples](#examples)
+- [Development](#development)
+- [Architecture](#architecture)
+
+## Overview
+
+Managing labels and taints on Kubernetes nodes is often tedious and error-prone — especially in clusters with dynamic node provisioning where nodes come and go. The `elx-nodegroup-controller` solves this by introducing the `NodeGroup` custom resource, which acts as a declarative specification of which nodes should carry which labels and taints.
+
+Key features:
+
+- **Declarative**: Define the desired state once; the controller continuously reconciles it.
+- **Persistent**: Labels and taints are automatically reapplied if manually removed.
+- **Cleanup on deletion**: When a `NodeGroup` is deleted, the controller removes the labels and taints it previously applied.
+- **Dynamic membership**: Nodes can be selected by exact name or by node group name patterns (useful for auto-scaled node groups).
+
+## How It Works
+
+1. You create a `NodeGroup` resource listing the nodes (by name or naming pattern) and the labels/taints you want applied.
+2. The controller watches both `NodeGroup` and `Node` resources.
+3. On each reconciliation loop, the controller ensures every member node has the specified labels and taints.
+4. If a `NodeGroup` is deleted, the controller cleans up all labels and taints it originally applied via a finalizer before allowing the resource to be removed.
+
+## Installation
+
+### Prerequisites
+
+- Kubernetes cluster >= 1.24
+- `kubectl` configured to talk to your cluster
+- `kustomize` (or use `kubectl apply -k`)
+
+### Deploy the Controller and CRD
 
 ```bash
 kustomize build config/default | kubectl apply -f -
 ```
 
-## Sample nodegroup manifest
+This creates the following resources in the `elx-nodegroup-controller-system` namespace:
 
-```yml
+| Resource | Name |
+|----------|------|
+| CRD | `nodegroups.k8s.elx.cloud` |
+| Namespace | `elx-nodegroup-controller-system` |
+| ServiceAccount | `controller-manager` |
+| ClusterRole | `manager-role` |
+| ClusterRoleBinding | `manager-rolebinding` |
+| Deployment | `controller-manager` |
+
+### Uninstall
+
+```bash
+kustomize build config/default | kubectl delete -f -
+```
+
+## Usage
+
+### NodeGroup API Reference
+
+```
+apiVersion: k8s.elx.cloud/v1alpha2
+kind: NodeGroup
+```
+
+`NodeGroup` is a cluster-scoped resource (no namespace required).
+
+#### Spec
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `members` | `[]string` | Explicit list of Kubernetes node names to include in this group. |
+| `nodeGroupNames` | `[]string` | Node naming patterns for dynamic membership. A node is included if any segment of its name (split on `-`) matches one of these values. |
+| `labels` | `map[string]string` | Labels to apply to all member nodes. |
+| `taints` | `[]corev1.Taint` | Taints to apply to all member nodes. Each taint has `key`, `value` (optional), and `effect` (`NoSchedule`, `PreferNoSchedule`, or `NoExecute`). |
+
+You can use `members`, `nodeGroupNames`, or both together — their results are combined.
+
+### Examples
+
+#### Apply labels and taints to specific nodes
+
+```yaml
 apiVersion: k8s.elx.cloud/v1alpha2
 kind: NodeGroup
 metadata:
-  name: nodegroup-sample
+  name: compute-nodes
 spec:
-  members: 
-    - node1 # Kubernetes node name
-  nodeGroupNames: 
-    - node0 # Kubernetes nodegroup name, used for clusters with dynamic node naming
+  members:
+    - worker-node-1
+    - worker-node-2
   labels:
-    name: value
+    workload-type: compute
+    environment: production
   taints:
-    - effect: "NoSchedule"
-      key: key
-      value: value
+    - key: workload-type
+      value: compute
+      effect: NoSchedule
 ```
+
+#### Dynamic membership via node group name patterns
+
+Useful in clusters where auto-scaling creates nodes with predictable name prefixes. A node named `gpu-a100-abc123` would match the pattern `gpu` because `gpu` is one of the `-`-separated segments of the name.
+
+```yaml
+apiVersion: k8s.elx.cloud/v1alpha2
+kind: NodeGroup
+metadata:
+  name: gpu-nodes
+spec:
+  nodeGroupNames:
+    - gpu
+  labels:
+    hardware: gpu
+  taints:
+    - key: nvidia.com/gpu
+      value: "true"
+      effect: NoSchedule
+```
+
+#### Mixed: explicit members and dynamic patterns
+
+```yaml
+apiVersion: k8s.elx.cloud/v1alpha2
+kind: NodeGroup
+metadata:
+  name: spot-nodes
+spec:
+  members:
+    - specific-spot-node-1
+  nodeGroupNames:
+    - spot
+  labels:
+    capacity-type: spot
+  taints:
+    - key: spot-instance
+      value: "true"
+      effect: NoExecute
+```
+
+#### Common operations
+
+```bash
+# Create or update a NodeGroup
+kubectl apply -f nodegroup.yaml
+
+# List all NodeGroups in the cluster
+kubectl get nodegroups
+
+# Inspect a NodeGroup
+kubectl describe nodegroup gpu-nodes
+
+# Delete a NodeGroup (cleans up labels and taints from member nodes)
+kubectl delete nodegroup gpu-nodes
+```
+
+## Development
+
+### Prerequisites
+
+- Go 1.22+
+- Docker
+- `controller-gen`
+- `kustomize`
+- `envtest` (for running tests)
+
+### Build
+
+```bash
+make build
+```
+
+### Run tests
+
+```bash
+make test
+```
+
+### Generate CRD manifests and DeepCopy methods
+
+```bash
+make manifests
+make generate
+```
+
+### Build and push the container image
+
+```bash
+make docker-build docker-push IMG=<registry>/<image>:<tag>
+```
+
+### Deploy from a custom image
+
+```bash
+make deploy IMG=<registry>/<image>:<tag>
+```
+
+## Architecture
+
+The controller is built with [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) (Kubebuilder v3 layout).
+
+### Reconciliation flow
+
+```
+NodeGroup created/updated
+        │
+        ▼
+ Build member list
+ (spec.members + nodes matching spec.nodeGroupNames)
+        │
+        ▼
+ NodeGroup being deleted?
+     │         │
+    Yes        No
+     │          │
+     ▼          ▼
+ Remove        Add finalizer
+ labels/taints (if missing)
+ from nodes         │
+     │              ▼
+     ▼        Apply labels to
+ Remove       member nodes
+ finalizer         │
+                   ▼
+             Apply taints to
+             member nodes
+```
+
+### Watching Nodes
+
+The controller also watches `Node` resources. When a node changes (e.g., it is recreated after being replaced by the autoscaler), the controller looks up which `NodeGroup`s list that node as a member and triggers reconciliation for each of them — ensuring labels and taints are immediately reapplied.
+
+### Finalizer
+
+The controller uses the `k8s.elx.cloud/finalizer` finalizer on each `NodeGroup`. This ensures the controller has the opportunity to clean up labels and taints from member nodes before Kubernetes removes the `NodeGroup` object.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,146 @@
+# NodeGroup API Reference
+
+## Overview
+
+The `NodeGroup` resource is a cluster-scoped custom resource provided by the `k8s.elx.cloud` API group. It defines a group of nodes and the labels and taints that should be applied to them.
+
+```
+Group:   k8s.elx.cloud
+Version: v1alpha2
+Kind:    NodeGroup
+Scope:   Cluster
+```
+
+> **Note:** `v1alpha1` is also supported for backwards compatibility but is deprecated. Use `v1alpha2` for all new resources.
+
+---
+
+## Spec
+
+### `spec.members`
+
+**Type:** `[]string`  
+**Required:** No
+
+A list of Kubernetes node names to explicitly include in this group.
+
+```yaml
+spec:
+  members:
+    - worker-node-1
+    - worker-node-2
+```
+
+Each entry must be an exact match of the node's `.metadata.name`.
+
+---
+
+### `spec.nodeGroupNames`
+
+**Type:** `[]string`  
+**Required:** No
+
+A list of name segments to use for dynamic node discovery. The controller will include any node in the cluster whose name contains one of these segments when the node name is split on the `-` character.
+
+```yaml
+spec:
+  nodeGroupNames:
+    - gpu
+    - spot
+```
+
+**How matching works:**
+
+Given a node named `gpu-a100-abc123`, the name is split into parts: `["gpu", "a100", "abc123"]`. If any part appears in `nodeGroupNames`, the node is added to the group.
+
+This is useful in clusters where node pools use a consistent prefix in their generated names (e.g., `gpu-*`, `spot-*`).
+
+You may use `members` and `nodeGroupNames` simultaneously — the resulting member list is the union of both.
+
+---
+
+### `spec.labels`
+
+**Type:** `map[string]string`  
+**Required:** No
+
+Labels to apply to all member nodes. The controller adds these labels and will reapply them if they are manually removed.
+
+```yaml
+spec:
+  labels:
+    workload-type: compute
+    environment: production
+    team: platform
+```
+
+Labels that are not in the spec are not touched by the controller. The controller only removes labels it previously applied when the `NodeGroup` is deleted.
+
+---
+
+### `spec.taints`
+
+**Type:** `[]corev1.Taint`  
+**Required:** No
+
+Taints to apply to all member nodes. The controller adds these taints if they are not already present.
+
+```yaml
+spec:
+  taints:
+    - key: workload-type
+      value: compute
+      effect: NoSchedule
+    - key: dedicated
+      value: gpu
+      effect: NoExecute
+```
+
+Each taint has the following fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `key` | string | Yes | The taint key. |
+| `value` | string | No | The taint value. |
+| `effect` | string | Yes | `NoSchedule`, `PreferNoSchedule`, or `NoExecute`. |
+| `timeAdded` | timestamp | No | Set automatically by Kubernetes for `NoExecute` taints. |
+
+---
+
+## Status
+
+The `status` subresource is currently reserved and contains no fields.
+
+---
+
+## Full Example
+
+```yaml
+apiVersion: k8s.elx.cloud/v1alpha2
+kind: NodeGroup
+metadata:
+  name: gpu-nodes
+spec:
+  # Include specific nodes by exact name
+  members:
+    - gpu-node-static-1
+
+  # Include nodes dynamically by name segment
+  nodeGroupNames:
+    - gpu
+
+  # Labels to apply to all members
+  labels:
+    hardware: gpu
+    capacity-type: on-demand
+    team: ml-platform
+
+  # Taints to apply to all members
+  taints:
+    - key: nvidia.com/gpu
+      value: "true"
+      effect: NoSchedule
+    - key: dedicated
+      value: gpu
+      effect: NoExecute
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,178 @@
+# Development Guide
+
+## Prerequisites
+
+| Tool | Minimum Version | Purpose |
+|------|----------------|---------|
+| Go | 1.22 | Build the controller |
+| Docker | any recent | Build container images |
+| `kubectl` | any recent | Deploy to a cluster |
+| `kustomize` | v4+ | Manage manifests |
+| `controller-gen` | v0.14.0 | Generate CRD manifests and DeepCopy |
+| `envtest` | bundled via `setup-envtest` | Run integration tests |
+
+Install Go toolchain dependencies:
+
+```bash
+make controller-gen      # Install controller-gen locally
+make envtest             # Install envtest binaries locally
+```
+
+---
+
+## Repository Layout
+
+```
+.
+├── api/
+│   ├── v1alpha1/           # Deprecated CRD version (supported for migration)
+│   │   └── nodegroup_types.go
+│   └── v1alpha2/           # Current storage version
+│       ├── groupversion_info.go
+│       ├── nodegroup_types.go
+│       └── zz_generated.deepcopy.go
+├── config/
+│   ├── crd/                # Generated CRD manifest
+│   ├── default/            # Kustomization for full deployment
+│   ├── manager/            # Deployment manifest
+│   ├── rbac/               # RBAC manifests
+│   └── samples/            # Example NodeGroup resources
+├── controllers/
+│   ├── nodegroup_controller.go      # Reconciliation logic
+│   └── nodegroup_controller_test.go # Integration tests
+├── hack/                   # Helper scripts (boilerplate header)
+├── main.go                 # Controller manager entry point
+├── Dockerfile
+├── Makefile
+└── go.mod
+```
+
+---
+
+## Common Tasks
+
+### Build the binary
+
+```bash
+make build
+```
+
+Output: `./bin/manager`
+
+### Run tests
+
+```bash
+make test
+```
+
+Tests use `envtest` to spin up a local Kubernetes API server. Test coverage output is written to `cover.out`.
+
+### Generate code
+
+After modifying the API types in `api/v1alpha2/nodegroup_types.go`, regenerate:
+
+```bash
+# Regenerate CRD manifests (config/crd/bases/)
+make manifests
+
+# Regenerate DeepCopy methods (zz_generated.deepcopy.go)
+make generate
+```
+
+Always commit the generated files alongside your type changes.
+
+### Format and lint
+
+```bash
+make fmt   # gofmt
+make vet   # go vet
+```
+
+### Build the container image
+
+```bash
+make docker-build IMG=<registry>/<image>:<tag>
+```
+
+For multi-architecture builds (amd64, arm64, s390x, ppc64le):
+
+```bash
+make docker-buildx IMG=<registry>/<image>:<tag>
+```
+
+### Push the image
+
+```bash
+make docker-push IMG=<registry>/<image>:<tag>
+```
+
+### Deploy from a custom image
+
+```bash
+make deploy IMG=<registry>/<image>:<tag>
+```
+
+### Install only the CRD (no controller)
+
+```bash
+make install
+```
+
+### Uninstall the CRD
+
+```bash
+make uninstall
+```
+
+---
+
+## Adding a New API Version
+
+The project follows the Kubebuilder multi-version API pattern. To add a new version (e.g., `v1beta1`):
+
+1. Create the new version under `api/v1beta1/`.
+2. Add conversion functions (`hub.go` and `conversion.go`) if needed.
+3. Register the new version in `main.go`.
+4. Annotate the new type with `// +kubebuilder:storageversion` and remove it from the old version.
+5. Run `make manifests generate` to regenerate code.
+
+---
+
+## Controller Runtime Flags
+
+The `manager` binary accepts the following flags:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--metrics-bind-address` | `:8080` | Address for Prometheus metrics endpoint |
+| `--health-probe-bind-address` | `:8081` | Address for liveness/readiness probes |
+| `--leader-elect` | `false` | Enable leader election for HA deployments |
+
+The default Kustomize deployment enables `--leader-elect=true`.
+
+---
+
+## Testing
+
+Tests are written using [Ginkgo v2](https://onsi.github.io/ginkgo/) and [Gomega](https://onsi.github.io/gomega/) and run against a local Kubernetes API server managed by `envtest`.
+
+### Running a specific test
+
+```bash
+go test ./controllers/... -run "TestControllers/should apply labels"
+```
+
+### Test timeout
+
+Each test assertion polls with a 250ms interval and a 10-second timeout. Adjust these constants in `controllers/suite_test.go` if needed.
+
+### What is tested
+
+| Scenario | Description |
+|----------|-------------|
+| Finalizer management | Finalizer is added to new NodeGroups |
+| Label application | Labels from spec are applied to member nodes |
+| Taint application | Taints from spec are applied to member nodes |
+| Cleanup on deletion | Labels and taints are removed when NodeGroup is deleted |
+| Label/taint persistence | Re-applied if manually removed from a node |
+| Node lifecycle | Labels/taints restored when a node is recreated |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,182 @@
+# Operations Guide
+
+## Deployment
+
+### Install
+
+Deploy the controller and CRD with a single command:
+
+```bash
+kustomize build config/default | kubectl apply -f -
+```
+
+Verify the controller is running:
+
+```bash
+kubectl -n elx-nodegroup-controller-system get pods
+```
+
+Expected output:
+
+```
+NAME                                   READY   STATUS    RESTARTS   AGE
+controller-manager-<hash>              2/2     Running   0          30s
+```
+
+### Upgrade
+
+Apply the updated manifests:
+
+```bash
+kustomize build config/default | kubectl apply -f -
+```
+
+The controller deployment uses `RollingUpdate` by default, so upgrades are non-disruptive.
+
+### Uninstall
+
+```bash
+kustomize build config/default | kubectl delete -f -
+```
+
+> **Note:** Delete all `NodeGroup` resources before uninstalling to ensure the controller can clean up labels and taints from your nodes. If you uninstall the controller while `NodeGroup` resources exist, the nodes will keep the labels and taints but you will need to remove them manually.
+
+---
+
+## Managing NodeGroups
+
+### Create
+
+```bash
+kubectl apply -f my-nodegroup.yaml
+```
+
+### List
+
+```bash
+kubectl get nodegroups
+```
+
+### Inspect
+
+```bash
+kubectl describe nodegroup <name>
+```
+
+### Update
+
+Edit the spec and reapply:
+
+```bash
+kubectl apply -f my-nodegroup.yaml
+```
+
+Or edit in place:
+
+```bash
+kubectl edit nodegroup <name>
+```
+
+### Delete
+
+```bash
+kubectl delete nodegroup <name>
+```
+
+When a `NodeGroup` is deleted, the controller automatically removes the labels and taints it applied from all member nodes before the resource is removed from the cluster.
+
+---
+
+## Monitoring
+
+### Metrics
+
+The controller exposes Prometheus metrics on port `8080` (behind `kube-rbac-proxy` for authentication). Metrics follow the standard `controller-runtime` naming conventions:
+
+- `controller_runtime_reconcile_total` — total number of reconciliations
+- `controller_runtime_reconcile_errors_total` — total number of reconciliation errors
+- `controller_runtime_reconcile_time_seconds` — reconciliation duration histogram
+
+### Health Probes
+
+The controller exposes health probes on port `8081`:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `/healthz` | Liveness probe |
+| `/readyz` | Readiness probe |
+
+### Logs
+
+Fetch controller logs:
+
+```bash
+kubectl -n elx-nodegroup-controller-system logs -l control-plane=controller-manager -f
+```
+
+The controller uses structured (JSON) logging via `logr`/`zap`.
+
+---
+
+## Troubleshooting
+
+### Labels or taints not applied
+
+1. Check controller logs for errors:
+   ```bash
+   kubectl -n elx-nodegroup-controller-system logs -l control-plane=controller-manager
+   ```
+
+2. Verify the `NodeGroup` resource is valid:
+   ```bash
+   kubectl describe nodegroup <name>
+   ```
+
+3. Confirm node names in `spec.members` match actual node names exactly:
+   ```bash
+   kubectl get nodes
+   ```
+
+4. For `nodeGroupNames`, verify the segment matches by inspecting node names:
+   ```bash
+   kubectl get nodes -o name | sed 's|node/||' | tr '-' '\n' | sort -u
+   ```
+
+### NodeGroup stuck in deletion
+
+If a `NodeGroup` is stuck with a deletion timestamp and is not being removed, the controller may not be running or may be failing to process the finalization. Check:
+
+```bash
+# Is the controller running?
+kubectl -n elx-nodegroup-controller-system get pods
+
+# Are there errors?
+kubectl -n elx-nodegroup-controller-system logs -l control-plane=controller-manager
+
+# What finalizers are present?
+kubectl get nodegroup <name> -o jsonpath='{.metadata.finalizers}'
+```
+
+If the controller is permanently unavailable and you need to force-delete the resource (accepting that labels/taints on nodes will **not** be cleaned up):
+
+```bash
+kubectl patch nodegroup <name> -p '{"metadata":{"finalizers":[]}}' --type=merge
+```
+
+---
+
+## Security Considerations
+
+The controller runs with the minimum required RBAC permissions:
+
+- **Nodes**: `get`, `list`, `watch`, `update`, `patch`
+- **NodeGroups**: full CRUD + status + finalizers
+
+The controller pod is configured with:
+
+- Non-root user (`uid: 65532`)
+- Read-only root filesystem
+- No privilege escalation
+- Distroless base image (minimal attack surface)
+- Tolerations for all `NoSchedule` taints (so the controller can run even on tainted nodes)
+- Node affinity that avoids control-plane nodes


### PR DESCRIPTION
## Summary

- Rewrites `README.md` with a full project overview, installation steps, usage examples with three worked scenarios, and an architecture section including a reconciliation flow diagram
- Adds `docs/api-reference.md` — detailed field-level API docs for the `NodeGroup` CRD
- Adds `docs/operations.md` — deployment, upgrade, uninstall, monitoring, and troubleshooting guide
- Adds `docs/development.md` — repo layout, build/test/codegen workflow, and controller runtime flags reference

## Test plan

- [ ] Review README for accuracy against current codebase
- [ ] Verify all `kubectl` and `kustomize` commands are correct
- [ ] Confirm API field descriptions match `api/v1alpha2/nodegroup_types.go`
- [ ] Check Makefile targets listed in development guide match the actual `Makefile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)