### PR TITLE
fix: security and deployment hardening

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,11 +15,20 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=0"
         ports:
         - containerPort: 8443
           protocol: TCP
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,12 +34,17 @@ spec:
               - matchExpressions:
                   - key: node-role.kubernetes.io/control-plane
                     operator: DoesNotExist
-      # Ignore all NoSchedule taints
+      # Ignore all NoSchedule and NoExecute taints so the controller
+      # is never evicted by taints it manages.
       tolerations:
         - effect: NoSchedule
           operator: Exists
+        - effect: NoExecute
+          operator: Exists
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - command:
             - /manager
@@ -49,6 +54,12 @@ spec:
           name: manager
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
           livenessProbe:
             httpGet:
               path: /healthz

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -5,18 +5,6 @@ metadata:
   name: leader-election-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	k8sv1alpha2 "github.com/elastx/elx-nodegroup-controller/api/v1alpha2"
 	"github.com/elastx/elx-nodegroup-controller/controllers"
@@ -52,12 +53,10 @@ func main() {
 	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	opts := zap.Options{
-		Development: true,
-	}
+	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -65,6 +64,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "91389fa0.elx.cloud",


### PR DESCRIPTION
## Summary

- **Metrics endpoint**: `metricsAddr` flag is now wired into `ctrl.Options{Metrics}` — previously the value was parsed but silently discarded, leaving the metrics endpoint bound to all interfaces unprotected regardless of the `--metrics-bind-address` flag
- **Leader election default**: changed from `false` to `true` so running the binary directly is safe without relying on the manifest passing `--leader-elect`
- **Production logger**: removed `Development: true` from zap options — development mode panics on DPanic and emits stack traces at WARN level, both inappropriate for production
- **NoExecute toleration**: manager Deployment now also tolerates `NoExecute` taints so the controller cannot be self-evicted by taints it applies to nodes
- **Container security hardening**: manager container gains `capabilities.drop: [ALL]`, `readOnlyRootFilesystem: true`, and `seccompProfile: RuntimeDefault`; pod securityContext gains `seccompProfile: RuntimeDefault`
- **kube-rbac-proxy security context**: sidecar had no securityContext at all — now has full hardening matching the manager container
- **kube-rbac-proxy verbosity**: changed `--v=10` to `--v=0`; level 10 logs full request headers, tokens, and SubjectAccessReview bodies into the pod log stream
- **Leader election RBAC**: removed ConfigMap CRUD from the leader election Role — modern Kubernetes uses `coordination.k8s.io/leases` exclusively; the ConfigMap permissions are leftover Kubebuilder scaffolding

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Deploy to a cluster and verify metrics are only accessible on the configured bind address
- [ ] Verify the controller pod starts with the new securityContext (no permission errors from read-only filesystem)
- [ ] Apply a `NoExecute` taint to the node running the controller and verify the pod is not evicted
- [ ] Confirm leader election still works with default `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)