### PR TITLE
docs: NetworkPolicy best practices for the operations guide

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -180,3 +180,76 @@ The controller pod is configured with:
 - Distroless base image (minimal attack surface)
 - Tolerations for all `NoSchedule` taints (so the controller can run even on tainted nodes)
 - Node affinity that avoids control-plane nodes
+
+### NetworkPolicy
+
+The controller listens on two ports:
+
+| Port | Purpose | Expected callers |
+|------|---------|-----------------|
+| 8080 | Metrics (behind `kube-rbac-proxy`) | Prometheus scraper |
+| 8081 | Health probes (`/healthz`, `/readyz`) | Kubelet |
+
+Restricting ingress to these ports reduces the blast radius if another workload in the cluster is compromised. Because every cluster has a different Prometheus deployment topology (namespace, label selectors, and whether it runs inside or outside the cluster), no single NetworkPolicy can be shipped with the controller. The templates below cover the common cases — adapt the `namespaceSelector` / `podSelector` blocks to match your environment.
+
+**Deny all ingress by default, then allow only what is needed:**
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: elx-nodegroup-controller-manager
+  namespace: elx-nodegroup-controller-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+
+  ingress:
+    # Kubelet health probes (liveness / readiness on port 8081)
+    - ports:
+        - port: 8081
+          protocol: TCP
+
+    # Prometheus metrics scrape (port 8080 via kube-rbac-proxy).
+    # Replace the selectors below with whatever matches your Prometheus pod(s).
+    # Common variants are shown — uncomment the one that fits your setup.
+    - ports:
+        - port: 8080
+          protocol: TCP
+      from:
+        # Option A: Prometheus in a dedicated namespace with a known label
+        # - namespaceSelector:
+        #     matchLabels:
+        #       kubernetes.io/metadata.name: monitoring
+        #   podSelector:
+        #     matchLabels:
+        #       app.kubernetes.io/name: prometheus
+
+        # Option B: kube-prometheus-stack default labels
+        # - namespaceSelector:
+        #     matchLabels:
+        #       kubernetes.io/metadata.name: monitoring
+        #   podSelector:
+        #     matchLabels:
+        #       app.kubernetes.io/name: prometheus
+        #       operator.prometheus.io/name: kube-prometheus-stack-prometheus
+
+        # Option C: Any pod in a namespace labelled "monitoring=true"
+        # - namespaceSelector:
+        #     matchLabels:
+        #       monitoring: "true"
+```
+
+> **Note on egress:** The controller makes outbound calls only to the Kubernetes API server. If your cluster enforces egress policies, ensure the controller namespace has a policy permitting TCP to the API server address (typically port 443 or 6443). The default installation does not include an egress NetworkPolicy.
+
+**Verify the policy is not blocking health probes** after applying:
+
+```bash
+kubectl -n elx-nodegroup-controller-system get pods
+# Both containers should remain Ready; if the pod becomes unready, check that
+# the kubelet CIDR is not blocked and review:
+kubectl describe networkpolicy elx-nodegroup-controller-manager -n elx-nodegroup-controller-system
+```


### PR DESCRIPTION
## Summary

Adds a NetworkPolicy section to `docs/operations.md` under Security Considerations.

The controller exposes two ports (8080 metrics via kube-rbac-proxy, 8081 health probes). A NetworkPolicy restricting ingress to those ports is a good hardening step, but the exact policy cannot be shipped as a manifest because Prometheus topology varies per cluster (namespace, pod labels, in-cluster vs external).

The new section:
- Documents which ports are exposed and who is expected to call them
- Explains why we document rather than ship a manifest (public repo, cluster-specific selectors)
- Provides a template with three commented option variants for the Prometheus ingress rule (dedicated namespace, kube-prometheus-stack, namespace label)
- Notes the egress consideration for clusters with egress policies
- Includes a verification step to confirm health probes still pass after applying

No code changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)